### PR TITLE
Make it possible to construct a TcpListener from an OwnedFd

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("error taking ownership of a socket from a file descriptor: {0}")]
+    SocketFromFd(std::io::Error),
     #[error("error creating socket: {0}")]
     SocketNew(std::io::Error),
     #[error("error binding: {0}")]


### PR DESCRIPTION
This will make it possible to implement systemd socket activation in rqbit (https://github.com/ikatson/rqbit/pull/505).